### PR TITLE
Fix error when canceling Appointments that don't require a response

### DIFF
--- a/BulkDeleteAppointments.bas
+++ b/BulkDeleteAppointments.bas
@@ -25,7 +25,7 @@
 ' OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 '
 ' Description of functionality at  http://www.schlosser.info/outlook-delete-multiple-appointments
-' Beschreibung der FunktionalitÃ¤t: http://www.schlosser.info/outlook-viele-termine-absagen
+' Beschreibung der Funktionalität: http://www.schlosser.info/outlook-viele-termine-absagen
 '
 Private Type dateRange
     startDate As Date

--- a/BulkDeleteAppointments.bas
+++ b/BulkDeleteAppointments.bas
@@ -153,9 +153,6 @@ Sub DeleteItemWithDefaultMessage(oItem, cancelMsg)
                 oAppointItem.Send
           Case olMeetingReceived                                'Received meeting invitation
                 'MsgBox ("Invited Appointment: " + oAppointItem.Subject)
-                Debug.Print "Subject: " & oAppointItem.Subject
-                Debug.Print "Start Time: " & oAppointItem.Start
-                Debug.Print "End Time: " & oAppointItem.End
                 Set myMtg = oAppointItem.Respond(olMeetingDeclined, True, False)
                 If oAppointItem.ResponseRequested Then
                     myMtg.Body = cancelMsg

--- a/BulkDeleteAppointments.bas
+++ b/BulkDeleteAppointments.bas
@@ -25,7 +25,7 @@
 ' OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 '
 ' Description of functionality at  http://www.schlosser.info/outlook-delete-multiple-appointments
-' Beschreibung der Funktionalität: http://www.schlosser.info/outlook-viele-termine-absagen
+' Beschreibung der FunktionalitÃ¤t: http://www.schlosser.info/outlook-viele-termine-absagen
 '
 Private Type dateRange
     startDate As Date
@@ -54,7 +54,7 @@ Public Sub BulkDeleteAppointments()
     End If
     
     ' only proceed if items are selected by now, either automatically or manually
-    If itemsToDelete.Count > 0 Then
+    If Not itemsToDelete Is Nothing And itemsToDelete.Count > 0 Then
         For Each oAppt In itemsToDelete
             itemCount = itemCount + 1
         Next oAppt
@@ -62,7 +62,7 @@ Public Sub BulkDeleteAppointments()
           MsgBox ("Too many entries. Max 100 are deleted in one go. Aborted!")
         Else
         ' Show found entries, get confirmation string
-            cancelMsg = InputBox(Prompt:="Selected Date Range: " & datRange.startDate & " - " & datRange.endDate & "." & Chr$(13) & Chr$(13) & "Number of found Items: " & itemCount _
+            cancelMsg = InputBox(Prompt:="Selected Date Range: " & Format(datRange.startDate, "DDDDD HH:NN") & " - " & Format(datRange.endDate, "DDDDD HH:NN") & "." & Chr$(13) & Chr$(13) & "Number of found Items: " & itemCount _
             & Chr$(13) & Chr$(13) & "Enter your cancel message below please. Check the info above, there will be no further confirmation.", _
                   Title:="ENTER YOUR MESSAGE", Default:="I am on vacation.")
             If (cancelMsg <> "") Then
@@ -153,9 +153,14 @@ Sub DeleteItemWithDefaultMessage(oItem, cancelMsg)
                 oAppointItem.Send
           Case olMeetingReceived                                'Received meeting invitation
                 'MsgBox ("Invited Appointment: " + oAppointItem.Subject)
+                Debug.Print "Subject: " & oAppointItem.Subject
+                Debug.Print "Start Time: " & oAppointItem.Start
+                Debug.Print "End Time: " & oAppointItem.End
                 Set myMtg = oAppointItem.Respond(olMeetingDeclined, True, False)
-                myMtg.Body = cancelMsg
-                myMtg.Send
+                If oAppointItem.ResponseRequested Then
+                    myMtg.Body = cancelMsg
+                    myMtg.Send
+                End If
           Case olMeetingCanceled, olMeetingReceivedAndCanceled  'Received meeting invitation, updated afterwards
                 MsgBox ("Meeting has already been canceled, just trying to delete: " + oAppointItem.Subject)
                 oAppointItem.Delete
@@ -163,4 +168,3 @@ Sub DeleteItemWithDefaultMessage(oItem, cancelMsg)
         End Select
     End If
 End Sub
-


### PR DESCRIPTION
When declining meetings that don't require a response, Nothing is returned from the Respond method. As no response is possible, the cancelMsg is skipped for those meetings.

Also, changed the message prompt to include the time of the date range, so it becomes apparent that while the endDate is included, no events pass midnight are cancelled.